### PR TITLE
ci: build and test on newer node version, lint only on 12

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -24,7 +24,7 @@ jobs:
     # - prepare
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - run: npm i -g npm@6
       - run: npm i
       - run: npm run build
       - name: Require clean working directory
@@ -49,7 +50,7 @@ jobs:
     #  - prepare
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [12.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,7 +68,7 @@ jobs:
     #  - prepare
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -75,6 +76,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - run: npm i -g npm@6
       - run: npm i
       - run: npm run test
       - name: Require clean working directory


### PR DESCRIPTION
- ci: build and test on newer node version, lint only on 12
  - ci: pin to npm v6 for lockfile consistency

---
#### Blocking
- #15